### PR TITLE
create a endpoint to make a booking

### DIFF
--- a/src/routes/bookings.routes.ts
+++ b/src/routes/bookings.routes.ts
@@ -4,6 +4,6 @@ import { getBookingsById, makeBookings } from "../controllers/bookings.controlle
 import { isAuthenticated } from "../middlewares/verifyToken.middleware";
 
 router.get('/:id', isAuthenticated, getBookingsById);
-router.post('/', isAuthenticated, makeBookings);
+router.post('/create', isAuthenticated, makeBookings);
 
 export default router;

--- a/src/routes/bookings.routes.ts
+++ b/src/routes/bookings.routes.ts
@@ -1,8 +1,9 @@
 import express from "express";
 const router = express.Router();
-import { getBookingsById } from "../controllers/bookings.controllers";
+import { getBookingsById, makeBookings } from "../controllers/bookings.controllers";
 import { isAuthenticated } from "../middlewares/verifyToken.middleware";
 
 router.get('/:id', isAuthenticated, getBookingsById);
+router.post('/', isAuthenticated, makeBookings);
 
 export default router;

--- a/src/routes/swaggerDocs.ts
+++ b/src/routes/swaggerDocs.ts
@@ -982,7 +982,7 @@
 // CREATE A BOOKING
 /**
  * @swagger
- * /api/bookings:
+ * /api/bookings/create:
  *   post:
  *     summary: Create a booking
  *     description: Creates a new booking by validating the request body and forwarding it to the main backend service.

--- a/src/routes/swaggerDocs.ts
+++ b/src/routes/swaggerDocs.ts
@@ -978,3 +978,112 @@
  *                   type: string
  *                   description: Error message
  */
+
+// CREATE A BOOKING
+/**
+ * @swagger
+ * /api/bookings:
+ *   post:
+ *     summary: Create a booking
+ *     description: Creates a new booking by validating the request body and forwarding it to the main backend service.
+ *     tags:
+ *       - Bookings
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               experienceId:
+ *                 type: string
+ *                 description: The ID of the experience to be booked.
+ *                 example: "650f9f1bfc13ae1c79000001"
+ *               userId:
+ *                 type: string
+ *                 description: The ID of the user making the booking.
+ *                 example: "650f9f1bfc13ae1c79000002"
+ *               participants:
+ *                 type: integer
+ *                 description: The number of participants for the booking.
+ *                 example: 2
+ *               totalPrice:
+ *                 type: number
+ *                 description: The total price for the booking.
+ *                 example: 120.5
+ *             required:
+ *               - experienceId
+ *               - userId
+ *               - participants
+ *               - totalPrice
+ *     responses:
+ *       201:
+ *         description: Booking successfully created.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Booking confirmed"
+ *                 reserva:
+ *                   type: object
+ *                   properties:
+ *                     _id:
+ *                       type: string
+ *                       example: "650f9f1bfc13ae1c79000003"
+ *                     experienceId:
+ *                       type: string
+ *                       example: "650f9f1bfc13ae1c79000001"
+ *                     userId:
+ *                       type: string
+ *                       example: "650f9f1bfc13ae1c79000002"
+ *                     status:
+ *                       type: string
+ *                       description: The current status of the booking.
+ *                       example: "confirmed"
+ *                     bookingDate:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2024-11-25T10:30:00.000Z"
+ *                     totalPrice:
+ *                       type: number
+ *                       example: 120.5
+ *                     participants:
+ *                       type: integer
+ *                       example: 2
+ *                     paymentStatus:
+ *                       type: string
+ *                       description: The payment status of the booking.
+ *                       example: "paid"
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2024-11-24T15:00:00.000Z"
+ *       400:
+ *         description: Validation error or booking rejected.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Validation error"
+ *                 errors:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   example: ["participants must be greater than 0"]
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Error processing the request"
+ */

--- a/src/types/yup-validations.ts
+++ b/src/types/yup-validations.ts
@@ -141,3 +141,13 @@ export const updateReviewSchema = uploadReviewSchema.concat(
     })
 );
 
+// Schema for make a booking
+export const bookingSchema = yup.object().shape({
+    experienceId: yup.string().required(),
+    userId: yup.string().required(),
+    status: yup.string().oneOf(['pending', 'confirmed', 'canceled']).required(),
+    bookingDate: yup.date().required(),
+    totalPrice: yup.number().required(),
+    participants: yup.number().required(),
+    paymentStatus: yup.string().oneOf(['paid', 'pending']).required(),
+  });

--- a/swagger.json
+++ b/swagger.json
@@ -1369,7 +1369,7 @@
         }
       }
     },
-    "/api/bookings": {
+    "/api/bookings/create": {
       "post": {
         "summary": "Create a booking",
         "description": "Creates a new booking by validating the request body and forwarding it to the main backend service.",

--- a/swagger.json
+++ b/swagger.json
@@ -1368,6 +1368,157 @@
           }
         }
       }
+    },
+    "/api/bookings": {
+      "post": {
+        "summary": "Create a booking",
+        "description": "Creates a new booking by validating the request body and forwarding it to the main backend service.",
+        "tags": [
+          "Bookings"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "experienceId": {
+                    "type": "string",
+                    "description": "The ID of the experience to be booked.",
+                    "example": "650f9f1bfc13ae1c79000001"
+                  },
+                  "userId": {
+                    "type": "string",
+                    "description": "The ID of the user making the booking.",
+                    "example": "650f9f1bfc13ae1c79000002"
+                  },
+                  "participants": {
+                    "type": "integer",
+                    "description": "The number of participants for the booking.",
+                    "example": 2
+                  },
+                  "totalPrice": {
+                    "type": "number",
+                    "description": "The total price for the booking.",
+                    "example": 120.5
+                  }
+                },
+                "required": [
+                  "experienceId",
+                  "userId",
+                  "participants",
+                  "totalPrice"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Booking successfully created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Booking confirmed"
+                    },
+                    "reserva": {
+                      "type": "object",
+                      "properties": {
+                        "_id": {
+                          "type": "string",
+                          "example": "650f9f1bfc13ae1c79000003"
+                        },
+                        "experienceId": {
+                          "type": "string",
+                          "example": "650f9f1bfc13ae1c79000001"
+                        },
+                        "userId": {
+                          "type": "string",
+                          "example": "650f9f1bfc13ae1c79000002"
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "The current status of the booking.",
+                          "example": "confirmed"
+                        },
+                        "bookingDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "example": "2024-11-25T10:30:00.000Z"
+                        },
+                        "totalPrice": {
+                          "type": "number",
+                          "example": 120.5
+                        },
+                        "participants": {
+                          "type": "integer",
+                          "example": 2
+                        },
+                        "paymentStatus": {
+                          "type": "string",
+                          "description": "The payment status of the booking.",
+                          "example": "paid"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "example": "2024-11-24T15:00:00.000Z"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error or booking rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Validation error"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": [
+                        "participants must be greater than 0"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Error processing the request"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {},


### PR DESCRIPTION
**Crear un endpoint para gestionar la creación de reservas.**

- Implementado el controlador `makeBookings` para validar los datos entrantes utilizando `yup` y reenviar las solicitudes válidas al backend principal en Java para su procesamiento.
- Actualizado `bookings.routes.ts` para añadir un endpoint POST que permita crear reservas utilizando `makeBookings`.
- Ampliada la documentación de Swagger en `swaggerDocs.ts` y `swagger.json` para proporcionar especificaciones detalladas de la API, incluyendo esquemas de solicitud/respuesta y ejemplos.
- Añadido un nuevo `bookingSchema` en `yup-validations.ts` para validar campos de reservas como `experienceId`, `userId`, `participants` y `totalPrice`.
