### PR TITLE
create endpoint to update a review

### DIFF
--- a/src/routes/reviews.routes.ts
+++ b/src/routes/reviews.routes.ts
@@ -1,9 +1,10 @@
 import express from "express";
 const router = express.Router();
-import { uploadReview, deleteReview } from "../controllers/reviews.controllers";
+import { uploadReview, deleteReview, updateReview } from "../controllers/reviews.controllers";
 import { isAuthenticated } from "../middlewares/verifyToken.middleware";
 
 router.post('/create', isAuthenticated, uploadReview);
-router.delete('/:id', isAuthenticated, deleteReview)
+router.delete('/:id', isAuthenticated, deleteReview);
+router.put('/update', isAuthenticated, updateReview);
 
 export default router;

--- a/src/routes/swaggerDocs.ts
+++ b/src/routes/swaggerDocs.ts
@@ -1238,3 +1238,91 @@
  *                   type: string
  *                   example: "Error communicating with the verification service"
  */
+
+// UPDATE REWIEV ENDPOINT
+/**
+ * @swagger
+ * /api/reviews/update:
+ *   put:
+ *     summary: Actualiza una reseña existente
+ *     description: Permite a un usuario actualizar una reseña de una experiencia, siempre y cuando sea el creador de la reseña.
+ *     tags:
+ *       - Reviews
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               reviewId:
+ *                 type: string
+ *                 description: ID único de la reseña a actualizar
+ *                 example: "63f1f0a12345abcde6789012"
+ *               userId:
+ *                 type: string
+ *                 description: ID del usuario que intenta realizar la actualización
+ *                 example: "63f1f0b12345abcde6789013"
+ *               rating:
+ *                 type: integer
+ *                 description: Nueva calificación de la reseña (opcional)
+ *                 example: 4
+ *               comment:
+ *                 type: string
+ *                 description: Nuevo comentario de la reseña (opcional)
+ *                 example: "Excelente experiencia, muy recomendada."
+ *     responses:
+ *       200:
+ *         description: Reseña actualizada con éxito
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   description: Detalles de la reseña actualizada
+ *       400:
+ *         description: Error de validación o datos faltantes
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "reviewId and userId are required"
+ *       403:
+ *         description: El usuario no tiene permiso para actualizar la reseña
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "You do not have permission to update this review"
+ *       404:
+ *         description: Reseña no encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Review not found."
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Error updating review."
+ */

--- a/src/types/yup-validations.ts
+++ b/src/types/yup-validations.ts
@@ -132,14 +132,17 @@ export const uploadReviewSchema = yup.object().shape({
 });
 
 // Update schema for review
-export const updateReviewSchema = uploadReviewSchema.concat(
-    yup.object().shape({
-        experienceId: yup.string().nullable(),
-        rating: yup.number().nullable(),
-        comment: yup.string().nullable(),
-        date: yup.date().nullable(),
-    })
-);
+export const updateReviewSchema = yup.object().shape({
+    reviewId: yup.string().required("El ID de la reseña es obligatorio."),
+    userId: yup.string().required("El ID del usuario es obligatorio."),
+    rating: yup.number()
+      .min(1, "La calificación debe ser al menos 1.")
+      .max(5, "La calificación no puede ser mayor a 5.")
+      .nullable(),
+    comment: yup.string()
+      .max(500, "El comentario no puede superar los 500 caracteres.")
+      .nullable(),
+  });
 
 // Schema for make a booking
 export const bookingSchema = yup.object().shape({

--- a/swagger.json
+++ b/swagger.json
@@ -1739,6 +1739,133 @@
           }
         }
       }
+    },
+    "/api/reviews/update": {
+      "put": {
+        "summary": "Actualiza una reseña existente",
+        "description": "Permite a un usuario actualizar una reseña de una experiencia, siempre y cuando sea el creador de la reseña.",
+        "tags": [
+          "Reviews"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reviewId": {
+                    "type": "string",
+                    "description": "ID único de la reseña a actualizar",
+                    "example": "63f1f0a12345abcde6789012"
+                  },
+                  "userId": {
+                    "type": "string",
+                    "description": "ID del usuario que intenta realizar la actualización",
+                    "example": "63f1f0b12345abcde6789013"
+                  },
+                  "rating": {
+                    "type": "integer",
+                    "description": "Nueva calificación de la reseña (opcional)",
+                    "example": 4
+                  },
+                  "comment": {
+                    "type": "string",
+                    "description": "Nuevo comentario de la reseña (opcional)",
+                    "example": "Excelente experiencia, muy recomendada."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Reseña actualizada con éxito",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "Detalles de la reseña actualizada"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error de validación o datos faltantes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "reviewId and userId are required"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "El usuario no tiene permiso para actualizar la reseña",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "You do not have permission to update this review"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Reseña no encontrada",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Review not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error interno del servidor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Error updating review."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {},


### PR DESCRIPTION
### Implementación del endpoint PUT /api/reviews/update para actualizar reseñas

Se ha desarrollado un nuevo endpoint  que permite actualizar reseñas existentes de experiencias. La funcionalidad está diseñada para garantizar que solo el usuario que creó la reseña pueda actualizarla, cumpliendo con las siguientes validaciones y lógica de negocio:

Validaciones iniciales:

Se verifica que los campos obligatorios reviewId y userId estén presentes.
Se valida el cuerpo de la solicitud utilizando yup.
Autorización:

El sistema consulta al backend principal para verificar que la reseña existe y pertenece al usuario que solicita la actualización.
Si el usuario no tiene permisos, se devuelve un error 403.
Construcción dinámica de datos:

Solo se envían al backend principal los campos que realmente han cambiado (rating, comment), además de los campos obligatorios (reviewId, userId).

Gestión de errores:
Manejo de errores específicos para validaciones fallidas (400), acceso no autorizado (403), reseñas no encontradas (404) y errores internos del servidor (500).