### PR TITLE
mecanismo para borrar imágenes del bucket

### DIFF
--- a/src/controllers/imageUpload.controllers.ts
+++ b/src/controllers/imageUpload.controllers.ts
@@ -1,6 +1,6 @@
 import { Response, NextFunction, Request } from "express"
-import { generateUploadUrl } from '../middlewares/aws.middleware'
 import { sendImageUrlToJavaBackend } from '../services/javaBackendService'
+import { generateUploadUrl, deleteImageFromBucket } from '../middlewares/aws.middleware'
 
 const getPresignedUrl = async (req: Request, res: Response, next: NextFunction) => {
     const { fileName } = req.body
@@ -41,5 +41,19 @@ const uploadImage = async (req: Request, res: Response, next: NextFunction) => {
     }
 }
 
-export { getPresignedUrl, uploadImage }
+const deleteImage = async (req: Request, res: Response, next: NextFunction) => {
+    const { key } = req.body
 
+    if (!key) {
+        return res.status(400).json({ errorMessage: 'Key is required' })
+    }
+
+    try {
+        await deleteImageFromBucket(process.env.AWS_S3_BUCKET_NAME!, key)
+        res.status(200).json({ message: 'Image deleted successfully' })
+    } catch (error) {
+        res.status(500).json({ errorMessage: 'Error deleting image', error })
+    }
+}
+
+export { getPresignedUrl, uploadImage, deleteImage }

--- a/src/middlewares/aws.middleware.ts
+++ b/src/middlewares/aws.middleware.ts
@@ -1,4 +1,4 @@
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3"
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3"
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { fromEnv } from "@aws-sdk/credential-provider-env"
 
@@ -12,4 +12,9 @@ const generateUploadUrl = async (bucket: string, key: string) => {
     return getSignedUrl(s3, command, { expiresIn: 3600 })
 }
 
-export { s3, generateUploadUrl }
+const deleteImageFromBucket = async (bucket: string, key: string) => {
+    const command = new DeleteObjectCommand({ Bucket: bucket, Key: key })
+    await s3.send(command);
+}
+
+export { s3, generateUploadUrl, deleteImageFromBucket }

--- a/src/routes/upload.routes.ts
+++ b/src/routes/upload.routes.ts
@@ -1,9 +1,9 @@
 import express from "express"
 const router = express.Router()
-import { getPresignedUrl, uploadImage } from "../controllers/imageUpload.controllers"
-import { isAuthenticated } from "../middlewares/verifyToken.middleware"
+import { getPresignedUrl, uploadImage, deleteImage } from "../controllers/imageUpload.controllers"
 
-router.post("/presigned-url", isAuthenticated, getPresignedUrl)
-router.post("/image", isAuthenticated, uploadImage)
+router.post("/presigned-url", getPresignedUrl)
+router.post("/image", uploadImage)
+router.delete("/image", deleteImage)
 
 export default router


### PR DESCRIPTION
implementación de mecanismo para borrar las imágenes que se hayan subido al bucket si falla el envío del form del que pertenecen.

Por ejemplo:
Si se suben las imágenes para crear una experiencia, pero la experiencia no se puede crear, las imágenes se borran para que no queden "sueltas" en el bucket ocupando espacio